### PR TITLE
aws-sdk to devDepencies and region variable in the role

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "aws-sdk": "^2.6.7",
     "uuid": "^2.0.3"
+  },
+  "devDependencies": {
+    "aws-sdk": "^2.6.3"
   }
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -15,7 +15,7 @@ provider:
         - dynamodb:PutItem
         - dynamodb:UpdateItem
         - dynamodb:DeleteItem
-      Resource: arn:aws:dynamodb:${self:provider.region}:*:*
+      Resource: arn:aws:dynamodb:${opt:region, self:provider.region}:*:*
 
 functions:
   create:

--- a/serverless.yml
+++ b/serverless.yml
@@ -15,7 +15,7 @@ provider:
         - dynamodb:PutItem
         - dynamodb:UpdateItem
         - dynamodb:DeleteItem
-      Resource: "arn:aws:dynamodb:us-east-1:*:*"
+      Resource: arn:aws:dynamodb:${self:provider.region}:*:*
 
 functions:
   create:


### PR DESCRIPTION
Very nice and simple example how to use DynamoDB with Serverless 👍 

This PR includes couple small improvements
- Moves aws-sdk to devDependecies - aws-sdk version 2.6.3 is included in the Lambda execution environment
- Changes the IAM role to use `${self:provider.region}` variable instead of hardcoded region
